### PR TITLE
Fix pre-Initialized ExtEvents not invoking

### DIFF
--- a/Runtime/EventElements/PersistentListener.cs
+++ b/Runtime/EventElements/PersistentListener.cs
@@ -199,7 +199,7 @@
                 return;
             }
 
-            _initializationSuccessful = Initialize();
+            Initialize();
 
             if (_initializationSuccessful)
                 InvokeImpl(args);
@@ -249,6 +249,7 @@
             InitializeArguments();
 
             _initializationComplete = true;
+            _initializationSuccessful = true;
             return true;
         }
 


### PR DESCRIPTION
In the current commit, the `PersistentListener._initializationSuccessful` flag is only set when the `PersistentListener` initializes itself during invocation. The `PersistentListener._initializationComplete` flag is set properly during the initialization call. Both of these flags must be set for the invocation to execute.

This leads to a failure to invocate, with no error message, if `ExtEvent.Initialize()` is called before `ExtEvent.Invoke()`; the contained `PersistentListener`s will have the `_initializationComplete` flag set, but `_initializationSuccessful` not set, in spite of no issues.

This PR sets the `_initializationSuccessful` flag within `PersistentListener.Initialize()` so pre-initialized `ExtEvent`s will fire properly.