### PR TITLE
Fix preprocessor directive not supporting newer Unity versions

### DIFF
--- a/Editor/AOTGeneration/BuildPreprocessor.cs
+++ b/Editor/AOTGeneration/BuildPreprocessor.cs
@@ -100,7 +100,7 @@
             // if IL2CPP setting and OptimizeSpeed, emit generic types usage.
 #if UNITY_2021_2_OR_NEWER
             var codeGeneration =
-    #if UNITY_2022
+    #if UNITY_2022_1_OR_NEWER
                 PlayerSettings.GetIl2CppCodeGeneration(NamedBuildTarget.FromBuildTargetGroup(EditorUserBuildSettings.selectedBuildTargetGroup));
     #else
                 EditorUserBuildSettings.il2CppCodeGeneration;


### PR DESCRIPTION
When using ExtEvents with Unity 6 an error was thrown that the EditorUserBuildSettings.il2CppCodeGeneration is obsolete and PlayerSettings.GetIl2CppCodeGeneration should be used instead. This was, because the preprocessor directive that ensured that the right member is used, only used PlayerSettings.GetIl2CppCodeGeneration for Unity 2022, but not newer versions.

To support newer versions, I just changed the preprocessor directive to also include any version, newer than Unity 2022.